### PR TITLE
fixing the images path on PrintPreview

### DIFF
--- a/src/components/PrintPreview.vue
+++ b/src/components/PrintPreview.vue
@@ -95,7 +95,7 @@ import { computed, ref } from 'vue'
 import { jsPDF } from 'jspdf'
 
 // Import the back card image
-import backCardImage from '/image/back-card.webp'
+import backCardImage from '/images/back-card.webp'
 
 const props = defineProps({
   selectedCards: {


### PR DESCRIPTION
Fixing the path used by PrintPreview.vue to search for the project images.